### PR TITLE
Set default StatusCode to 200

### DIFF
--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -74,6 +74,8 @@ func (a *apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Write([]byte(ce.Error()))
 		return
+	} else if rsp.StatusCode == 0 {
+		rsp.StatusCode = http.StatusOK
 	}
 
 	for _, header := range rsp.GetHeader() {


### PR DESCRIPTION
Without the default value, I'll need to write this code in every function.
```
	defer func() {
		if err == nil {
			rsp.StatusCode = http.StatusOK
		}
	}()
```