### PR TITLE
add resolver interface

### DIFF
--- a/resolver/grpc/grpc.go
+++ b/resolver/grpc/grpc.go
@@ -1,0 +1,27 @@
+// Package grpc resolves using http path
+package grpc
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+type Resolver struct{}
+
+func (r *Resolver) Resolve(req *http.Request) (string, error) {
+	// /foo.Bar/Service
+	if req.URL.Path == "/" {
+		return "", errors.New("unknown name")
+	}
+	// [foo.Bar, Service]
+	parts := strings.Split(req.URL.Path[1:], "/")
+	// [foo, Bar]
+	name := strings.Split(parts[0], ".")
+	// foo
+	return strings.Join(name[:len(name)-1], "."), nil
+}
+
+func (r *Resolver) String() string {
+	return "grpc"
+}

--- a/resolver/host/host.go
+++ b/resolver/host/host.go
@@ -1,0 +1,16 @@
+// Package host resolves using http host
+package host
+
+import (
+	"net/http"
+)
+
+type Resolver struct{}
+
+func (r *Resolver) Resolve(req *http.Request) (string, error) {
+	return req.Host, nil
+}
+
+func (r *Resolver) String() string {
+	return "host"
+}

--- a/resolver/path/path.go
+++ b/resolver/path/path.go
@@ -1,0 +1,22 @@
+// Package path resolves using http path
+package path
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+type Resolver struct{}
+
+func (r *Resolver) Resolve(req *http.Request) (string, error) {
+	if req.URL.Path == "/" {
+		return "", errors.New("unknown name")
+	}
+	parts := strings.Split(req.URL.Path[1:], "/")
+	return parts[0], nil
+}
+
+func (r *Resolver) String() string {
+	return "path"
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -1,0 +1,12 @@
+// Package resolver resolves a http request to an endpoint
+package resolver
+
+import (
+	"net/http"
+)
+
+// Resolver resolves requests to endpoints
+type Resolver interface {
+	Resolve(r *http.Request) (string, error)
+	String() string
+}

--- a/resolver/vpath/vpath.go
+++ b/resolver/vpath/vpath.go
@@ -1,0 +1,38 @@
+// Package vpath resolves using http path and recognised versioned urls
+package path
+
+import (
+	"errors"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+type Resolver struct{}
+
+var (
+	re = regexp.MustCompile("^v[0-9]+$")
+)
+
+func (r *Resolver) Resolve(req *http.Request) (string, error) {
+	if req.URL.Path == "/" {
+		return "", errors.New("unknown name")
+	}
+
+	parts := strings.Split(req.URL.Path[1:], "/")
+
+	if len(parts) == 1 {
+		return parts[0], nil
+	}
+
+	// /v1/foo
+	if re.MatchString(parts[0]) {
+		return parts[1], nil
+	}
+
+	return parts[0], nil
+}
+
+func (r *Resolver) String() string {
+	return "path"
+}


### PR DESCRIPTION
Working on changing how the router is composed.

Resolver handles retrieving a name from a request. This allows us to configure it in a more flexible way.