### PR TITLE
Add support for GET requests when using handler=rpc

### DIFF
--- a/handler/rpc/rpc_test.go
+++ b/handler/rpc/rpc_test.go
@@ -1,0 +1,95 @@
+package rpc
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/micro/go-api/proto"
+)
+
+func TestRequestPayloadFromRequest(t *testing.T) {
+
+	// our test event so that we can validate serialising / deserializing of true protos works
+	protoEvent := go_api.Event{
+		Name: "Test",
+	}
+
+	protoBytes, err := proto.Marshal(&protoEvent)
+	if err != nil {
+		t.Fatal("Failed to marshal proto", err)
+	}
+
+	jsonBytes, err := json.Marshal(protoEvent)
+	if err != nil {
+		t.Fatal("Failed to marshal proto to JSON ", err)
+	}
+
+	t.Run("extracting a proto from a POST request", func(t *testing.T) {
+		r, err := http.NewRequest("POST", "http://localhost/my/path", bytes.NewReader(protoBytes))
+		if err != nil {
+			t.Fatalf("Failed to created http.Request: %v", err)
+		}
+
+		extByte, err := requestPayloadFromRequest(r)
+		if err != nil {
+			t.Fatalf("Failed to extract payload from request: %v", err)
+		}
+		if string(extByte) != string(protoBytes) {
+			t.Fatalf("Expected %v and %v to match", string(extByte), string(protoBytes))
+		}
+	})
+
+	t.Run("extracting JSON from a POST request", func(t *testing.T) {
+		r, err := http.NewRequest("POST", "http://localhost/my/path", bytes.NewReader(jsonBytes))
+		if err != nil {
+			t.Fatalf("Failed to created http.Request: %v", err)
+		}
+
+		extByte, err := requestPayloadFromRequest(r)
+		if err != nil {
+			t.Fatalf("Failed to extract payload from request: %v", err)
+		}
+		if string(extByte) != string(jsonBytes) {
+			t.Fatalf("Expected %v and %v to match", string(extByte), string(jsonBytes))
+		}
+	})
+
+	t.Run("extracting params from a GET request", func(t *testing.T) {
+
+		r, err := http.NewRequest("GET", "http://localhost/my/path", nil)
+		if err != nil {
+			t.Fatalf("Failed to created http.Request: %v", err)
+		}
+
+		q := r.URL.Query()
+		q.Add("name", "Test")
+		r.URL.RawQuery = q.Encode()
+
+		extByte, err := requestPayloadFromRequest(r)
+		if err != nil {
+			t.Fatalf("Failed to extract payload from request: %v", err)
+		}
+		if string(extByte) != string(jsonBytes) {
+			t.Fatalf("Expected %v and %v to match", string(extByte), string(jsonBytes))
+		}
+	})
+
+	t.Run("GET request with no params", func(t *testing.T) {
+
+		r, err := http.NewRequest("GET", "http://localhost/my/path", nil)
+		if err != nil {
+			t.Fatalf("Failed to created http.Request: %v", err)
+		}
+
+		extByte, err := requestPayloadFromRequest(r)
+		if err != nil {
+			t.Fatalf("Failed to extract payload from request: %v", err)
+		}
+		if string(extByte) != "" {
+			t.Fatalf("Expected %v and %v to match", string(extByte), "")
+		}
+	})
+}


### PR DESCRIPTION
This extracts query string params into the underlying service's request body.
It allows the caller to make `GET` requests and pass in parameters using query strings.

Taking the [rpc example](https://github.com/micro/examples/tree/master/api/rpc):
**Existing functionality:**
POST:
```
curl -H 'Content-Type: application/json' -d '{"name": "john"}' "http://localhost:8080/example/call"
{"message":"got your request john"} 
```
GET:
```
curl -H 'Content-Type: application/json' "http://localhost:8080/example/call?name=john"
Method not allowed
```

**New Functionality:**
GET:
```
curl -H 'Content-Type: application/json' "http://localhost:8080/example/call?name=john"
{"message":"got your request john"}
```
POST:
```
curl -H 'Content-Type: application/json' -d '{"name": "john"}' "http://localhost:8080/example/call"
{"message":"got your request john"} 
```