### PR TITLE
fix synchronization issue

### DIFF
--- a/router/registry/registry.go
+++ b/router/registry/registry.go
@@ -105,7 +105,7 @@ func (r *registryRouter) process(res *registry.Result) {
 	}
 
 	// get entry from cache
-	service, err := r.rc.GetService(res.Service.Name)
+	service, err := r.opts.Registry.GetService(res.Service.Name)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The router's watch is not syncing with rcache's watch. It happens that the router is processing watch event but the rcache still doesn't receive the watch event. Therefore, the router will get the old service from the rcache.