### PR TITLE
fix  selector return deregister node

### DIFF
--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -66,7 +66,7 @@ func (a *apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// create the context from headers
 	cx := ctx.FromRequest(r)
 	// create strategy
-	so := selector.WithStrategy(strategy(service.Services))
+	so := selector.WithStrategy(strategy())
 
 	if err := c.Call(cx, req, rsp, client.WithSelectOption(so)); err != nil {
 		w.Header().Set("Content-Type", "application/json")

--- a/handler/api/util.go
+++ b/handler/api/util.go
@@ -99,8 +99,8 @@ func requestToProto(r *http.Request) (*api.Request, error) {
 }
 
 // strategy is a hack for selection
-func strategy(services []*registry.Service) selector.Strategy {
-	return func(_ []*registry.Service) selector.Next {
+func strategy() selector.Strategy {
+	return func(services []*registry.Service) selector.Next {
 		// ignore input to this function, use services above
 		return selector.Random(services)
 	}

--- a/handler/rpc/rpc.go
+++ b/handler/rpc/rpc.go
@@ -60,8 +60,8 @@ func (b *buffer) Write(_ []byte) (int, error) {
 }
 
 // strategy is a hack for selection
-func strategy(services []*registry.Service) selector.Strategy {
-	return func(_ []*registry.Service) selector.Next {
+func strategy() selector.Strategy {
+	return func(services []*registry.Service) selector.Next {
 		// ignore input to this function, use services above
 		return selector.Random(services)
 	}
@@ -105,7 +105,7 @@ func (h *rpcHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := h.opts.Service.Client()
 
 	// create strategy
-	so := selector.WithStrategy(strategy(service.Services))
+	so := selector.WithStrategy(strategy())
 
 	// get payload
 	br, err := requestPayload(r)


### PR DESCRIPTION
The function rpc.strategy(services []*registry.Service) will return a closure function, which will save param services.

When any backend service change, eg: restart，the gateway's [selector](https://github.com/micro/go-plugins/blob/master/client/grpc/grpc.go#L405)  will call the closure, and it may return the deregister node, which from the save param.